### PR TITLE
Add q&a category for the Project 1 assignment

### DIFF
--- a/install/data/categories.json
+++ b/install/data/categories.json
@@ -34,5 +34,15 @@
         "color": "#ffffff",
         "icon" : "fa-question",
         "order": 3
+    },
+    {
+        "name": "Q&A",
+        "description": "Got a question? Ask and we'll answer!",
+        "descriptionParsed": "<p>Got a question? Ask and we'll answer!</p>\n",
+        "bgColor": "#e95c5a",
+        "color": "#ffffff",
+        "icon" : "fa-question",
+        "order": 5
     }
+
 ]


### PR DESCRIPTION
A Q&A Category was added for the Project 1 assignment description so that we can use this category page to test our changes related to the project. 

<img width="1358" alt="Screenshot 2024-09-16 at 11 36 42 AM" src="https://github.com/user-attachments/assets/60a837f8-9545-4921-bd67-1382b6d050df">
